### PR TITLE
Add port unallocation functionality to admin panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [1.1.9] - 2025-12-01
+
+### Added
+- Port unallocation functionality in admin panel to remove project assignment from ports
+- "Unallocate" button in PortList view that appears when a port has a project assigned
+- `unallocatePort` function in portfolio store for unallocating ports from projects
+
+### Changed
+- PortList view now displays "Unallocate" button alongside Edit and Delete buttons for allocated ports
+- Unallocate button styled with yellow accent color to distinguish from delete action
+
+### Technical Details
+- Unallocation sets port `name` field to `null`, removing project assignment while preserving port record
+- Unallocate button only visible when `port.name` is not null/empty
+- Confirmation dialog prompts user before unallocating port
+- Port list automatically refreshes after unallocation to reflect updated state
+- Files updated: portfolio.ts, PortList.vue
+
+---
+
 ## [1.1.8] - 2025-12-01
 
 ### Added

--- a/frontend/src/stores/portfolio.ts
+++ b/frontend/src/stores/portfolio.ts
@@ -476,6 +476,30 @@ export const usePortfolioStore = defineStore('portfolio', () => {
     }
   }
 
+  async function unallocatePort(id: string) {
+    loading.value = true
+    error.value = null
+    try {
+      const response = await fetch(`${API_BASE_URL}/ports/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: null }),
+      })
+      if (!response.ok) {
+        const err = await response.json()
+        throw new Error(err.error || 'Failed to unallocate port')
+      }
+      const result = await response.json()
+      await fetchPorts()
+      return result
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Unknown error'
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
   // Check port availability (checks both DB allocation and runtime status)
   async function checkPortAvailability(portNumber: number): Promise<{
     available: boolean
@@ -573,6 +597,7 @@ export const usePortfolioStore = defineStore('portfolio', () => {
     createPort,
     updatePort,
     deletePort,
+    unallocatePort,
     checkPortAvailability,
     logClick,
     fetchTrafficStats,

--- a/frontend/src/views/admin/PortList.vue
+++ b/frontend/src/views/admin/PortList.vue
@@ -176,6 +176,13 @@
                         Edit
                       </router-link>
                       <button
+                        @click="handleUnallocate(project.frontend.id)"
+                        class="btn-glass px-3 py-1.5 rounded-lg text-xs font-semibold text-yellow-200 dark:text-yellow-300 hover:text-yellow-100 dark:hover:text-yellow-200 transition-all"
+                        :disabled="unallocating === project.frontend.id"
+                      >
+                        {{ unallocating === project.frontend.id ? 'Unallocating...' : 'Unallocate' }}
+                      </button>
+                      <button
                         @click="handleDelete(project.frontend.id)"
                         class="btn-glass px-3 py-1.5 rounded-lg text-xs font-semibold text-red-200 dark:text-red-300 hover:text-red-100 dark:hover:text-red-200 transition-all"
                         :disabled="deleting === project.frontend.id"
@@ -210,6 +217,13 @@
                       >
                         Edit
                       </router-link>
+                      <button
+                        @click="handleUnallocate(project.backend.id)"
+                        class="btn-glass px-3 py-1.5 rounded-lg text-xs font-semibold text-yellow-200 dark:text-yellow-300 hover:text-yellow-100 dark:hover:text-yellow-200 transition-all"
+                        :disabled="unallocating === project.backend.id"
+                      >
+                        {{ unallocating === project.backend.id ? 'Unallocating...' : 'Unallocate' }}
+                      </button>
                       <button
                         @click="handleDelete(project.backend.id)"
                         class="btn-glass px-3 py-1.5 rounded-lg text-xs font-semibold text-red-200 dark:text-red-300 hover:text-red-100 dark:hover:text-red-200 transition-all"
@@ -275,6 +289,14 @@
                       >
                         Edit
                       </router-link>
+                      <button
+                        v-if="port.name"
+                        @click="handleUnallocate(port.id)"
+                        class="btn-glass px-3 py-1.5 rounded-lg text-xs font-semibold text-yellow-200 dark:text-yellow-300 hover:text-yellow-100 dark:hover:text-yellow-200 mr-2 transition-all"
+                        :disabled="unallocating === port.id"
+                      >
+                        {{ unallocating === port.id ? 'Unallocating...' : 'Unallocate' }}
+                      </button>
                       <button
                         @click="handleDelete(port.id)"
                         class="btn-glass px-3 py-1.5 rounded-lg text-xs font-semibold text-red-200 dark:text-red-300 hover:text-red-100 dark:hover:text-red-200 transition-all"
@@ -344,6 +366,14 @@
                         Edit
                       </router-link>
                       <button
+                        v-if="port.name"
+                        @click="handleUnallocate(port.id)"
+                        class="btn-glass px-3 py-1.5 rounded-lg text-xs font-semibold text-yellow-200 dark:text-yellow-300 hover:text-yellow-100 dark:hover:text-yellow-200 mr-2 transition-all"
+                        :disabled="unallocating === port.id"
+                      >
+                        {{ unallocating === port.id ? 'Unallocating...' : 'Unallocate' }}
+                      </button>
+                      <button
                         @click="handleDelete(port.id)"
                         class="btn-glass px-3 py-1.5 rounded-lg text-xs font-semibold text-red-200 dark:text-red-300 hover:text-red-100 dark:hover:text-red-200 transition-all"
                         :disabled="deleting === port.id"
@@ -376,6 +406,7 @@ import { usePortfolioStore, type TrafficStats, type Project } from '../../stores
 const router = useRouter()
 const store = usePortfolioStore()
 const deleting = ref<string | null>(null)
+const unallocating = ref<string | null>(null)
 const viewMode = ref<'by-type' | 'by-project'>('by-type')
 const trafficStats = ref<TrafficStats[]>([])
 const loadingStats = ref(false)
@@ -620,6 +651,21 @@ async function handleDelete(id: string) {
     alert(error instanceof Error ? error.message : 'Failed to delete port')
   } finally {
     deleting.value = null
+  }
+}
+
+async function handleUnallocate(id: string) {
+  if (!confirm('Are you sure you want to unallocate this port from its project? The port will remain but will no longer be assigned to any project.')) {
+    return
+  }
+
+  unallocating.value = id
+  try {
+    await store.unallocatePort(id)
+  } catch (error) {
+    alert(error instanceof Error ? error.message : 'Failed to unallocate port')
+  } finally {
+    unallocating.value = null
   }
 }
 </script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "scripts": {
     "dev:full": "DEV_FULL=true concurrently --kill-others-on-fail --kill-others \"npm run dev:api\" \"npm run dev:frontend\"",
     "dev:api": "cd api && npm run dev:api",

--- a/reasonlog.md
+++ b/reasonlog.md
@@ -24,6 +24,7 @@ The document content is captured in two different formats, one optimized for hum
 
 | Version | Date | Component | Intent | Reasoning | Problems Solved | Goals Achieved |
 |---------|------|-----------|--------|-----------|-----------------|----------------|
+| 1.1.9 | 01/12/25 | port-unallocation | Add port unallocation functionality to admin panel | Implemented ability to unallocate ports from projects without deleting the port record. This allows administrators to remove project assignments when ports need to be reassigned or freed up, while preserving the port configuration. The unallocation sets the port's name field to null, effectively removing the project association. Added "Unallocate" button that appears conditionally when a port has a project assigned, styled with yellow accent to distinguish from delete action. Includes confirmation dialog to prevent accidental unallocation. The feature works in both table view (by server type) and project-grouped view, maintaining consistency across the admin interface. | No way to remove project assignment from ports without deleting the port; had to manually edit port to clear project association; inefficient workflow for port reassignment | Port unallocation without deletion; conditional button visibility; confirmation dialog for safety; consistent UI across view modes; improved port management workflow |
 | 1.1.8 | 01/12/25 | port-availability-checking | Add authoritative port availability checking API endpoint | Created dedicated API endpoint for checking port availability that combines both database allocation status and runtime port usage. This provides a single source of truth for port availability, preventing race conditions and stale data issues. The endpoint returns comprehensive information including whether port is reserved, active, which project reserved it, and which PID is using it. Frontend now uses this authoritative endpoint instead of relying on local state, ensuring accuracy and preventing allocation conflicts. | No authoritative way to check port availability; frontend relied on potentially stale local state; race conditions when multiple users check ports simultaneously | Authoritative port availability checking; single source of truth for port status; prevention of race conditions; accurate availability information |
 | 1.1.8 | 01/12/25 | port-validation-enhancement | Enhance port validation to check both database allocation and runtime status | Enhanced port creation and update validation to check both whether a port is reserved in the database and whether it's actively in use at runtime. This dual-check approach prevents allocating ports that are either already reserved or currently active, even if not in the database. Validation now provides clear error messages indicating whether a port is reserved by another project or actively in use with PID information. This prevents port conflicts and provides better debugging information. | Port validation only checked database, missing runtime active ports; unclear error messages when ports were unavailable; ports could be allocated even if actively in use | Dual validation (DB + runtime); prevention of port conflicts; clear error messages with context; better debugging information |
 | 1.1.8 | 01/12/25 | port-conflict-detection | Improve port conflict detection for project-server type combinations | Enhanced conflict detection to prevent allocating multiple ports of the same server type to the same project. The validation checks both new format (direct project ID match) and legacy format (project-slug with server type suffix) to ensure compatibility. This prevents accidental duplicate allocations and maintains data integrity. The check is performed both during creation and update operations, with clear error messages indicating which existing port conflicts. | No validation preventing multiple ports of same server type per project; legacy format ports not properly detected; unclear conflict messages | Prevention of duplicate port allocations per project-server type; support for both new and legacy formats; clear conflict error messages; improved data integrity |
@@ -56,6 +57,35 @@ The document content is captured in two different formats, one optimized for hum
   "versioning": "semantic",
   "format": "reasonlog",
   "versions": [
+    {
+      "version": "1.1.9",
+      "date": "01/12/25",
+      "reasons": [
+        {
+          "component": "port-unallocation",
+          "intent": "Add port unallocation functionality to admin panel",
+          "reasoning": "Implemented ability to unallocate ports from projects without deleting the port record. This allows administrators to remove project assignments when ports need to be reassigned or freed up, while preserving the port configuration. The unallocation sets the port's name field to null, effectively removing the project association. Added \"Unallocate\" button that appears conditionally when a port has a project assigned, styled with yellow accent to distinguish from delete action. Includes confirmation dialog to prevent accidental unallocation. The feature works in both table view (by server type) and project-grouped view, maintaining consistency across the admin interface.",
+          "problemsSolved": [
+            "No way to remove project assignment from ports without deleting the port",
+            "Had to manually edit port to clear project association",
+            "Inefficient workflow for port reassignment"
+          ],
+          "goalsAchieved": [
+            "Port unallocation without deletion",
+            "Conditional button visibility",
+            "Confirmation dialog for safety",
+            "Consistent UI across view modes",
+            "Improved port management workflow"
+          ],
+          "files": [
+            "frontend/src/stores/portfolio.ts",
+            "frontend/src/views/admin/PortList.vue"
+          ],
+          "alternativesConsidered": [],
+          "dependencies": []
+        }
+      ]
+    },
     {
       "version": "1.1.8",
       "date": "01/12/25",


### PR DESCRIPTION
Added ability to unallocate ports from projects without deleting the port record. Implemented unallocatePort function in portfolio store that sets port name to null. Added "Unallocate" button in PortList view that appears conditionally when port has project assigned, styled with yellow accent. Button works in both table view (by server type) and project-grouped view. Includes confirmation dialog to prevent accidental unallocation. Port list automatically refreshes after unallocation.

Updated CHANGELOG.md, package.json (v1.1.9), and reasonlog.md.

Files: portfolio.ts, PortList.vue