### PR TITLE
feat(index): add hero project search with keyboard navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## [1.1.11] - 2025-03-06
+
+### Added
+- Hero project search/selection bar on index view (PartitionList)
+- Filter projects by name on keyup with dropdown results
+- Arrow Up/Down keyboard navigation through filtered project list
+- Enter to select highlighted project and navigate; Escape to close dropdown
+
+### Changed
+- Centered logo, title, and hero search on index view
+- Index header layout uses flex with items-center for centered alignment
+
+### Technical Details
+- Projects fetched via store.fetchProjects() on mount for search data
+- Dropdown shows project name and tagline; selection navigates to /projects/:slug
+- Files updated: PartitionList.vue
+
+---
+
 ## [1.1.10] - 2025-12-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ If no seed file is found, the database will be initialized empty and ready for m
 
 ### Public Portfolio Views
 
-- **Home Page** (`/`): Grid view of all partitions
+- **Home Page** (`/`): Grid view of all partitions with hero project search
+  - Search/filter projects by name on keyup
+  - Arrow Up/Down to navigate, Enter to select, Escape to close
 - **Partition Detail** (`/partitions/:slug`): Shows all projects in a partition with featured projects highlighted
 - **Project Detail** (`/projects/:slug`): Full project information with associated partitions
 - **App Store View** (`/apps/:slug`): App Store-style presentation with screenshot galleries
@@ -161,6 +163,8 @@ Full CRUD interface accessible at `/admin`:
 
 ### UI/UX Features
 
+- **Hero Project Search**: Index view search bar to quickly find and jump to any project
+  - Type to filter by project name; arrow keys to navigate; Enter to select
 - **Glassmorphism Design**: Modern glass-effect UI with smooth animations
 - **Dark/Light Theme**: Theme toggle with persistent storage
 - **Responsive Layout**: Mobile-first design that works on all screen sizes

--- a/frontend/src/views/PartitionList.vue
+++ b/frontend/src/views/PartitionList.vue
@@ -2,8 +2,8 @@
   <div class="relative">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       <!-- Header -->
-      <div class="mb-16 fade-in-up">
-        <div class="flex items-center gap-4 mb-6">
+      <div class="mb-16 fade-in-up flex flex-col items-center text-center">
+        <div class="flex items-center justify-center gap-4 mb-6">
           <img 
             src="/logo.svg" 
             alt="Portfolio Logo" 
@@ -15,6 +15,51 @@
             </h1>
             <p class="text-xl text-white/60 dark:text-slate-500 font-light transition-colors">Showcasing innovation and creativity</p>
           </div>
+        </div>
+
+        <!-- Hero project search / selection -->
+        <div class="relative max-w-2xl mt-10 w-full">
+          <div class="relative">
+            <input
+              v-model="searchQuery"
+              type="text"
+              placeholder="Search projects..."
+              class="w-full px-6 py-4 pl-14 pr-12 rounded-2xl glass-strong text-white dark:text-slate-300 placeholder-white/50 dark:placeholder-slate-500 text-lg font-medium focus:ring-2 focus:ring-white/30 focus:border-white/40 transition-all"
+              @keyup="onSearchKeyup"
+              @keydown="onSearchKeydown"
+              @focus="showDropdown = true"
+              @blur="onSearchBlur"
+              autocomplete="off"
+            />
+            <svg class="absolute left-5 top-1/2 -translate-y-1/2 w-5 h-5 text-white/60 dark:text-slate-500 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          </div>
+          <transition name="dropdown">
+            <div
+              ref="dropdownRef"
+              v-if="showDropdown && (searchQuery.length > 0 || filteredProjects.length > 0)"
+              class="absolute top-full left-0 right-0 mt-2 max-h-80 overflow-y-auto rounded-2xl glass-strong border border-white/20 dark:border-slate-600/50 shadow-2xl z-50"
+            >
+              <div v-if="filteredProjects.length === 0" class="px-6 py-8 text-center text-white/60 dark:text-slate-500">
+                No projects match "{{ searchQuery }}"
+              </div>
+              <button
+                v-for="(project, index) in filteredProjects"
+                :key="project.id"
+                :data-index="index"
+                type="button"
+                :class="[
+                  'w-full px-6 py-4 text-left transition-colors flex items-center gap-3 first:rounded-t-2xl last:rounded-b-2xl',
+                  highlightedIndex === index ? 'bg-white/15 dark:bg-slate-600/40' : 'hover:bg-white/10 dark:hover:bg-slate-700/30'
+                ]"
+                @mousedown.prevent="selectProject(project)"
+              >
+                <span class="text-white dark:text-slate-300 font-medium">{{ project.name }}</span>
+                <span v-if="project.tagline" class="text-white/50 dark:text-slate-500 text-sm truncate flex-1">{{ project.tagline }}</span>
+              </button>
+            </div>
+          </transition>
         </div>
       </div>
       
@@ -70,10 +115,83 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
-import { usePortfolioStore } from '../stores/portfolio'
+import { ref, computed, onMounted, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { usePortfolioStore, type Project } from '../stores/portfolio'
 
 const store = usePortfolioStore()
+const router = useRouter()
+
+const projects = ref<Project[]>([])
+const searchQuery = ref('')
+const showDropdown = ref(false)
+const highlightedIndex = ref(0)
+const dropdownRef = ref<HTMLElement | null>(null)
+
+const filteredProjects = computed(() => {
+  const q = searchQuery.value.trim().toLowerCase()
+  if (!q) return projects.value
+  return projects.value.filter((p) => p.name.toLowerCase().includes(q))
+})
+
+watch([searchQuery, filteredProjects], () => {
+  highlightedIndex.value = filteredProjects.value.length > 0 ? 0 : -1
+})
+
+watch(showDropdown, (visible) => {
+  if (visible && filteredProjects.value.length > 0) {
+    highlightedIndex.value = 0
+  } else if (!visible) {
+    highlightedIndex.value = -1
+  }
+})
+
+function onSearchKeyup() {
+  showDropdown.value = true
+}
+
+function onSearchKeydown(e: KeyboardEvent) {
+  if (!showDropdown.value || filteredProjects.value.length === 0) return
+
+  if (e.key === 'ArrowDown') {
+    e.preventDefault()
+    highlightedIndex.value = (highlightedIndex.value + 1) % filteredProjects.value.length
+    scrollHighlightedIntoView()
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault()
+    highlightedIndex.value =
+      highlightedIndex.value <= 0
+        ? filteredProjects.value.length - 1
+        : highlightedIndex.value - 1
+    scrollHighlightedIntoView()
+  } else if (e.key === 'Enter') {
+    e.preventDefault()
+    const project = filteredProjects.value[highlightedIndex.value]
+    if (project) selectProject(project)
+  } else if (e.key === 'Escape') {
+    e.preventDefault()
+    showDropdown.value = false
+    highlightedIndex.value = -1
+  }
+}
+
+function scrollHighlightedIntoView() {
+  if (!dropdownRef.value || highlightedIndex.value < 0) return
+  const el = dropdownRef.value.querySelector(`[data-index="${highlightedIndex.value}"]`)
+  el?.scrollIntoView({ block: 'nearest' })
+}
+
+function onSearchBlur() {
+  // Delay to allow mousedown on dropdown item to fire first
+  setTimeout(() => { showDropdown.value = false }, 150)
+}
+
+function selectProject(project: Project) {
+  searchQuery.value = ''
+  showDropdown.value = false
+  highlightedIndex.value = -1
+  router.push(`/projects/${project.slug}`)
+}
 
 // Map partition names/slugs to logo files
 const getPartitionLogo = (partition: any): string | null => {
@@ -103,16 +221,30 @@ const getPartitionLogo = (partition: any): string | null => {
   return null
 }
 
-onMounted(() => {
+onMounted(async () => {
   // Scroll to top when component mounts
   window.scrollTo({ top: 0, behavior: 'instant' })
   
   store.fetchPartitions()
-  
+  const fetched = await store.fetchProjects()
+  projects.value = Array.isArray(fetched) ? fetched : []
+
   // Ensure we're at the top after data loads
   setTimeout(() => {
     window.scrollTo({ top: 0, behavior: 'instant' })
   }, 0)
 })
 </script>
+
+<style scoped>
+.dropdown-enter-active,
+.dropdown-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.dropdown-enter-from,
+.dropdown-leave-to {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+</style>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "scripts": {
     "dev:full": "DEV_FULL=true concurrently --kill-others-on-fail --kill-others \"npm run dev:api\" \"npm run dev:frontend\"",
     "dev:api": "cd api && npm run dev:api",


### PR DESCRIPTION
- Add search/selection bar on index view to filter projects by name on keyup
- Arrow Up/Down to navigate list; Enter to select, Escape to close
- Center logo, title, and hero search in header
- Fetch projects on mount for search data; selection navigates to /projects/:slug

Bump to 1.1.11